### PR TITLE
Add missing lokesh/lightbox2 library and update leaflet/leaflet library.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,10 +69,10 @@
             "type": "package",
             "package": {
                 "name": "leaflet/leaflet",
-                "version": "v0.7.7",
+                "version": "1.0.3",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://github.com/Leaflet/Leaflet/archive/v0.7.7.zip",
+                    "url": "https://github.com/Leaflet/Leaflet/archive/v1.0.3.zip",
                     "type": "zip"
                 }
             }
@@ -113,6 +113,18 @@
                     "url": "https://github.com/loopindex/ckeditor-track-changes",
                     "type": "git",
                     "reference": "origin/master"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "lokesh/lightbox2",
+                "version": "2.9.0",
+                "type": "drupal-library",
+                "dist": {
+                    "url": "https://github.com/lokesh/lightbox2/archive/v2.9.0.zip",
+                    "type": "zip"
                 }
             }
         }


### PR DESCRIPTION
Hello,

I am trying to test the df distribution using composer install.

I run the following command :

`composer create-project acquia/df-project:dev-8.x-2.x`

because composer create-project acquia/df-project:^8.1.0 did not work.

As the libraries where declared and required in acquia/df and the repositories declared in acquia/df composer.json could not be dynamically read, here is an update of acquia/df-project composer.json.

Thanks for the review.